### PR TITLE
Added TLS and Env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-powerstore-metrics-exporter

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+powerstore-metrics-exporter

--- a/config.yml
+++ b/config.yml
@@ -1,13 +1,15 @@
 exporter:
   port: 9010
   reqLimit: 200
+  cert: ./server.crt # Path to your TLS certificate file Remove for HTTP
+  key: ./server.key # Path to your TLS certificate file Remove for HTTP
 log:
   # type is [logfmt or json]
   type: logfmt
   path: ./powerstoreExporter.out.log
   level: info
 storageList:
-  - ip: 10.0.0.1
+  - ip: 10.0.0.1 #Env variables can be used. Eg $VARNAME
     user: your-first-powerstore-username
     password: your-first-powerstore-password
     apiVersion: v1

--- a/route/route.go
+++ b/route/route.go
@@ -94,8 +94,20 @@ func Run(config *utils.Config, logger log.Logger) {
 	httpPort := fmt.Sprintf(":%s", strconv.Itoa(config.Exporter.Port))
 	level.Info(logger).Log("msg", "~~~~~~~~~~~~~Start PowerStore Exporter~~~~~~~~~~~~~~")
 	level.Info(logger).Log("http-port", httpPort)
-	err := r.Run(httpPort)
-	if err != nil {
-		level.Error(logger).Log("msg", "Service startup failed", "err", err)
+
+	// Start HTTP server with or without TLS based on the presence of cert and key
+	if config.Exporter.Cert == "" || config.Exporter.Key == "" {
+		level.Info(logger).Log("msg", "Starting HTTP server without TLS")
+		err := r.Run(httpPort)
+		if err != nil {
+			level.Error(logger).Log("msg", "Service startup failed", "err", err)
+		}
+	} else {
+		level.Info(logger).Log("msg", "Starting HTTP server with TLS")
+		// Start HTTPS server
+		err := r.RunTLS(httpPort, config.Exporter.Cert, config.Exporter.Key)
+		if err != nil {
+			level.Error(logger).Log("msg", "Service startup failed", "err", err)
+		}
 	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -45,8 +45,10 @@ type Storage struct {
 }
 
 type Exporter struct {
-	Port     int `yaml:"port"`
-	ReqLimit int `yaml:"reqLimit"`
+	Port     int    `yaml:"port"`
+	ReqLimit int    `yaml:"reqLimit"`
+	Cert     string `yaml:"cert"`
+	Key      string `yaml:"key"`
 }
 
 type Logs struct {
@@ -66,8 +68,9 @@ func GetConfig(configPath string) *Config {
 	if err != nil {
 		stdlog.Fatalf("Error reading configuration file: %s\n", err)
 	}
+	expandedyaml := os.ExpandEnv(string(yamlFile))
 	config := Config{}
-	err = yaml.Unmarshal(yamlFile, &config)
+	err = yaml.Unmarshal([]byte(expandedyaml), &config)
 	if err != nil {
 		stdlog.Fatalf("Error Unmarshal yamL file: %s\n", err)
 	}
@@ -75,6 +78,8 @@ func GetConfig(configPath string) *Config {
 }
 
 func PrometheusHandler(registry *prometheus.Registry, logger log.Logger) gin.HandlerFunc {
+	//Check for cert and key file
+
 	handlerOpts := promhttp.HandlerOpts{
 		ErrorLog:      stdlog.New(log.NewStdlibAdapter(level.Error(logger)), "", 0),
 		ErrorHandling: promhttp.ContinueOnError,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,13 +17,15 @@
 package utils
 
 import (
+	stdlog "log"
+	"os"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"io/ioutil"
-	stdlog "log"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -60,7 +62,7 @@ type Config struct {
 }
 
 func GetConfig(configPath string) *Config {
-	yamlFile, err := ioutil.ReadFile(configPath)
+	yamlFile, err := os.ReadFile(configPath)
 	if err != nil {
 		stdlog.Fatalf("Error reading configuration file: %s\n", err)
 	}


### PR DESCRIPTION
Have added the ability to feed in a certificate and key file via the current config.yml. If a cert and key is present the exporter cuts over to hosting on HTTPS. 

Added the ability to put enviromental variables into the config as a way of obsucating secrets that may be in the configuration. 

HTTPS tested on and tested disables when no certificate of key is present. 

Tested expanding secrets. 

Tested with "VARNAME=127.0.0.1 go run main.go". Where ${VARNAME} is referenced within the config.yml

Removed dependancies that Github had identifed as bad. Replaced with OS package calls. 