### PR TITLE
Implement an "/all" endpoint for fetching all metrics at once.

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -130,6 +130,17 @@ func Run(config *utils.Config, logger log.Logger) {
 			metricsGroup.GET("nas", utils.PrometheusHandler(NasRegistry, logger))
 			metricsGroup.GET("volumeGroup", utils.PrometheusHandler(VolumeGroupRegistry, logger))
 			metricsGroup.GET("capacity", utils.PrometheusHandler(CapacityRegistry, logger))
+			metricsGroup.GET("all", utils.PrometheusHandler(prometheus.Gatherers{
+				ClusterRegistry,
+				PortRegistry,
+				FileSystemRegistry,
+				HardwareRegistry,
+				VolumeRegistry,
+				ApplianceRegistry,
+				NasRegistry,
+				VolumeGroupRegistry,
+				CapacityRegistry,
+			}, logger))
 		}
 		level.Info(logger).Log("msg", "The Powerstore is ready", "ip", storage.Ip)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -83,12 +83,12 @@ func GetConfig(configPath string) *Config {
 	return &config
 }
 
-func PrometheusHandler(registry *prometheus.Registry, logger log.Logger) gin.HandlerFunc {
+func PrometheusHandler(gatherer prometheus.Gatherer, logger log.Logger) gin.HandlerFunc {
 	handlerOpts := promhttp.HandlerOpts{
 		ErrorLog:      stdlog.New(log.NewStdlibAdapter(level.Error(logger)), "", 0),
 		ErrorHandling: promhttp.ContinueOnError,
 	}
-	h := promhttp.HandlerFor(registry, handlerOpts)
+	h := promhttp.HandlerFor(gatherer, handlerOpts)
 	return func(context *gin.Context) {
 		h.ServeHTTP(context.Writer, context.Request)
 	}


### PR DESCRIPTION
Use a gatherer interface instead of accessing the registries directly. This allows one to combine multiple registries at once.

Fixes #2 